### PR TITLE
修复后台用户修改头像后无法显示头像问题

### DIFF
--- a/src/views/sys/profile/index.vue
+++ b/src/views/sys/profile/index.vue
@@ -134,8 +134,8 @@
 
   function updateAvatar(data) {
     const userinfo = userStore.getUserInfo;
-    userinfo.avatar = data;
-    formdata.avatar = data;
+    userinfo.avatar = data.data;
+    formdata.avatar = data.data;
     userStore.setUserInfo(userinfo);
   }
 


### PR DESCRIPTION
后台修改用户信息页面，存在上传头像后无法显示头像问题。